### PR TITLE
Implement usage of sdk keys

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -8,7 +8,7 @@ const port = process.env.PORT || '3030';
 app.set('port', port);
 
 const server = http.createServer(app);
-const {initSubscribe}= require('../lib/jetstream');
+const {initSubscribe, fetchSdkKey}= require('../lib/jetstream');
 
 
 server.listen(port);
@@ -46,5 +46,6 @@ function onListening() {
     ? 'pipe ' + addr
     : 'port ' + addr.port;
   initSubscribe();
+  fetchSdkKey();
   debug('Listening on ' + bind);
 }

--- a/lib/jetstream.js
+++ b/lib/jetstream.js
@@ -1,6 +1,6 @@
 const { connect, StringCodec, consumerOpts, createInbox } = require('nats');
 const sc = StringCodec();
-const index = require("../routes/index");
+const i = require("../routes/index");
 let nc;
 let js;
 
@@ -35,6 +35,10 @@ async function fetchRecentData() {
   await publish('DATA.FullRuleSetRequest');
 }
 
+async function fetchSdkKey() {
+  await publish('KEY.sdkKeyRequest');
+}
+
 async function subscribeToFullRuleSet() {
   await createJetStreamConnect();
 
@@ -42,8 +46,8 @@ async function subscribeToFullRuleSet() {
 
   (async (sub) => {
     for await (const m of sub) {
-      console.log(`Message received: ${sc.decode(m.data)}`)
-      index.sendEventsToAll(sc.decode(m.data));
+      console.log(`Ruleset received: ${sc.decode(m.data)}`)
+      i.sendEventsToAll(sc.decode(m.data));
       m.ack();
     };
   })(sub);
@@ -51,8 +55,23 @@ async function subscribeToFullRuleSet() {
   subscriptionLog('FullRuleSet')(sub);
 }
 
+async function subscribeToSdkKey() {
+  await createJetStreamConnect();
+
+  const sub = await js.subscribe('KEY.sdkKey', config('sdkKey'));
+
+  (async (sub) => {
+    for await (const m of sub) {
+      console.log(`SDK key received: ${sc.decode(m.data)}`)
+      i.updateSdkKey(sc.decode(m.data));
+      m.ack();
+    };
+  })(sub);
+}
+
 async function initSubscribe() {
-  subscribeToFullRuleSet();
+  await subscribeToFullRuleSet();
+  await subscribeToSdkKey();
 }
 
 async function publish(stream, msg) {
@@ -68,3 +87,4 @@ async function publish(stream, msg) {
 exports.initSubscribe = initSubscribe;
 exports.publish = publish;
 exports.fetchRecentData = fetchRecentData;
+exports.fetchSdkKey = fetchSdkKey;


### PR DESCRIPTION
Scout can now send a jetstream message to request an sdk key from `pioneer` and perform a comparison of the client's sdk key with the sdk key being accessed from the client's authorization header.