### PR TITLE
updated constant imports/exports to be less verbose

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,4 +11,5 @@ const SUBSCRIPTION_SUBJECTS = {
 	}
 };
 
-module.exports = SUBSCRIPTION_SUBJECTS;
+module.exports.ruleset = SUBSCRIPTION_SUBJECTS.ruleset;
+module.exports.sdkKey = SUBSCRIPTION_SUBJECTS.sdkKey;

--- a/lib/jsw.js
+++ b/lib/jsw.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { connect, StringCodec, consumerOpts, createInbox } = require('nats');
 const sdkPoolManager = require('../lib/sdkPoolManager');
-const SUBSCRIPTION_SUBJECTS = require('./constants');
+const { ruleset, sdkKey } = require('./constants');
 // cannot import sendEventsToAll from index.js as that would result in a circular depency
 
 class JetstreamWrapper {
@@ -31,11 +31,11 @@ class JetstreamWrapper {
 	}
 
 	async fetchRecentData() {
-		await this.publish(SUBSCRIPTION_SUBJECTS.ruleset.fullSubject);
+		await this.publish(ruleset.fullSubject);
 	}
 
 	async fetchSdkKey() {
-		await this.publish(SUBSCRIPTION_SUBJECTS.sdkKey.fullSubject);
+		await this.publish(sdkKey.fullSubject);
 	}
 
 	async _subscribeToRequests({ streamName, subsetName, handler }) {
@@ -57,8 +57,8 @@ class JetstreamWrapper {
 			sdkPoolManager.sendEventsToAll(this.sc.decode(m.data));
 		};
 		this._subscribeToRequests({
-			streamName : SUBSCRIPTION_SUBJECTS.ruleset.streamName,
-			subsetName : SUBSCRIPTION_SUBJECTS.ruleset.subsetName,
+			streamName : ruleset.streamName,
+			subsetName : ruleset.subsetName,
 			handler
 		});
 	}
@@ -70,8 +70,8 @@ class JetstreamWrapper {
 			sdkPoolManager.updateSdkKey(sdkKey);
 		};
 		this._subscribeToRequests({
-			streamName : SUBSCRIPTION_SUBJECTS.sdkKey.streamName,
-			subsetName : SUBSCRIPTION_SUBJECTS.sdkKey.subsetName,
+			streamName : sdkKey.streamName,
+			subsetName : sdkKey.subsetName,
 			handler
 		});
 	}


### PR DESCRIPTION
Changed the import/exports of constants for ruleset names to be less verbose and easier to read.
Instead of : 
```js
const SUBSCRIPTION_SUBJECTS = require('./constants');
...
async fetchRecentData() {
  await this.publish(SUBSCRIPTION_SUBJECTS.ruleset.fullSubject);
}

```
We now have : 
```js
const { ruleset, sdkKey } = require('./constants');
...
async fetchRecentData() {
  await this.publish(ruleset.fullSubject);
}

```